### PR TITLE
Fix bug creating new webhook on each order

### DIFF
--- a/Model/BTCPay/BTCPayService.php
+++ b/Model/BTCPay/BTCPayService.php
@@ -422,7 +422,7 @@ class BTCPayService
                             if ($autoCancel) {
                                 $btcpayInvoices = $this->getInvoicesByOrderIds($magentoStoreId, [$order->getIncrementId()]);
                                 $isEverythingExpired = true;
-                                foreach ($btcpayInvoices->getInvoices() as $invoice) {
+                                foreach ($btcpayInvoices->all() as $invoice) {
                                     if (!$invoice->isExpired()) {
                                         $isEverythingExpired = false;
                                         break;
@@ -662,7 +662,7 @@ class BTCPayService
 
         $url = $this->getWebhookUrl($magentoStoreId);
 
-        foreach ($webhooks as $webhook) {
+        foreach ($webhooks->all() as $webhook) {
             $data = $webhook->getData();
             if ($data['url'] === $url) {
                 return $data;

--- a/Observer/CheckOrderStatus.php
+++ b/Observer/CheckOrderStatus.php
@@ -54,7 +54,7 @@ class CheckOrderStatus implements ObserverInterface
                 //Check Order Status
                 $invoices = $this->btcService->getInvoicesByOrderIds($currentStoreId, $orderIdArr);
 
-                $invoices = $invoices->getInvoices();
+                $invoices = $invoices->all();
                 if (count($invoices) !== 0) {
                     $invoice = $invoices[0];
 
@@ -65,7 +65,7 @@ class CheckOrderStatus implements ObserverInterface
                         //Only cancel when no other open invoices for the same orderId
                         $btcpayInvoices = $this->btcService->getInvoicesByOrderIds($currentStoreId, [$order->getIncrementId()]);
                         $isEverythingNew = true;
-                        foreach ($btcpayInvoices->getInvoices() as $invoice) {
+                        foreach ($btcpayInvoices->all() as $invoice) {
                             if (!$invoice->isNew()) {
                                 $isEverythingNew = false;
                                 break;


### PR DESCRIPTION
Some calls seems were not updated to breaking changes of v2 of the php library. This caused the webhook check to always return null and a new webhook was created on each checkout or config save. This lead also to DoS of the shop from BTCPay because of hundrets of webhooks firing at the same time. (eg. om mainnet demo one store had 1800 of them)

Fixes #15 

