### PR TITLE
Make sure the user needs to select store.

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -291,8 +291,11 @@ class Data
 
         $applicationIdentifier = 'magento2';
         $baseUrl = $this->btcPayService->getBtcPayServerBaseUrl();
+        $authorizeUrl = null;
 
-        $authorizeUrl = \BTCPayServer\Client\ApiKey::getAuthorizeUrl($baseUrl, \Storefront\BTCPay\Helper\Data::REQUIRED_API_PERMISSIONS, 'Magento 2 @ ' . $magentoRootDomain, true, false, $redirectToUrlAfterCreation, $applicationIdentifier);
+        if ($baseUrl) {
+            $authorizeUrl = \BTCPayServer\Client\ApiKey::getAuthorizeUrl($baseUrl, \Storefront\BTCPay\Helper\Data::REQUIRED_API_PERMISSIONS, 'Magento 2 @ ' . $magentoRootDomain, true, true, $redirectToUrlAfterCreation, $applicationIdentifier);
+        }
 
         return $authorizeUrl;
     }

--- a/Model/Config/ApiKeyComment.php
+++ b/Model/Config/ApiKeyComment.php
@@ -68,10 +68,10 @@ class ApiKeyComment implements CommentInterface
 
             $baseUrl = $this->btcPayService->getBtcPayServerBaseUrl();
             if ($baseUrl) {
-                $authorizeUrl = \BTCPayServer\Client\ApiKey::getAuthorizeUrl($baseUrl, \Storefront\BTCPay\Helper\Data::REQUIRED_API_PERMISSIONS, 'Magento 2 @ ' . $magentoRootDomain, true, false, $redirectToUrlAfterCreation, $applicationIdentifier);
+                $authorizeUrl = \BTCPayServer\Client\ApiKey::getAuthorizeUrl($baseUrl, \Storefront\BTCPay\Helper\Data::REQUIRED_API_PERMISSIONS, 'Magento 2 @ ' . $magentoRootDomain, true, true, $redirectToUrlAfterCreation, $applicationIdentifier);
                 $r = '<a target="_blank" href="' . $authorizeUrl . '">Generate API key</a>, but be sure to save any changes first.';
             } else {
-                $r = 'Make sure you configure the <strong>VTCPay Base Url</strong> above';
+                $r = 'Make sure you configure the <strong>BTCPay Base Url</strong> above';
             }
         }
         return $r;


### PR DESCRIPTION
At some point authorize URL behaviour was changed for quicker permission settings. We need to enable the store selection so the user can set the store and the proper permission get preset.

This fixes the problem when there are multiple stores configured on BTCPay server end - without the fix it won't select any store and the config would not get completed on Magento. Because there is no specific store returned by authorize callback but an api key for all stores.

![image](https://github.com/btcpayserver/magento2-plugin/assets/1136761/e7f7efc0-5373-40b1-a943-74de8fc2a35d)
