### PR TITLE
Fix empty BTCPay URL detection.

### DIFF
--- a/Model/BTCPay/BTCPayService.php
+++ b/Model/BTCPay/BTCPayService.php
@@ -164,6 +164,11 @@ class BTCPayService
     public function getBtcPayServerBaseUrl(): ?string
     {
         $r = $this->getStoreConfig('payment/btcpay/btcpay_base_url', 0);
+
+        if (!$r) {
+            return null;
+        }
+
         $r = rtrim((string)$r, '/') . '/';
         return $r;
     }


### PR DESCRIPTION
The "Generate API Key" was always shown even if the BTCPay URL was empty. Because the `getBtcPayServerBaseUrl()` never returned null but `/` if there was no URL set (due to the rtrim line).