### PR TITLE
Fix error on redirect if invoice already settled.

### DIFF
--- a/Controller/Redirect/ReturnAfterPayment.php
+++ b/Controller/Redirect/ReturnAfterPayment.php
@@ -103,6 +103,7 @@ class ReturnAfterPayment extends Action
                 $invoice = $this->btcPayService->getInvoice($btcPayInvoiceId, $btcPayStoreId, $magentoStoreId);
                 $isInvoiceExpired = $invoice->isExpired();
                 $isInvoiceProcessing = $invoice->isProcessing();
+                $isInvoiceSettled = $invoice->isSettled();
             }
         } else {
             // Order cannot be found
@@ -110,7 +111,7 @@ class ReturnAfterPayment extends Action
         }
 
         if ($order && $valid) {
-            if ($isInvoiceProcessing) {
+            if ($isInvoiceProcessing || $isInvoiceSettled) {
                 $this->checkoutSession->setLastQuoteId($order->getQuoteId());
                 $this->checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
                 $this->checkoutSession->setLastOrderId($order->getId());


### PR DESCRIPTION
Fixes #11 

The redirect after return to shop did not handle the case of when the invoice was settled. This happens with LN payments that settle immediately. Also if you click on the redirect link in the BTCPay invoice details after an on-chain invoice is settled.

This only handles that case and fixes above mentioned issue. Ideally all possible invoice states should be covered, e.g. partial payment, invalid etc. Would need a bit more refactor to structure things a bit better, - should I do that or we good for now? What you think @woutersamaey?