### PR TITLE
Mark overpaid orders as settled 

### DIFF
--- a/Model/BTCPay/BTCPayService.php
+++ b/Model/BTCPay/BTCPayService.php
@@ -382,7 +382,7 @@ class BTCPayService
                         $settledStatus = \Magento\Sales\Model\Order::STATE_COMPLETE;
 
                         if ($invoice->isOverpaid()) {
-                            $order->addCommentToStatusHistory('Payment confirmed: overpaid.');
+                            $order->addCommentToStatusHistory('Payment confirmed: overpaid.', $settledStatus, true);
                         } elseif ($order->canInvoice()) {
 
                             // You can't be sure of the amount, when marked manually the additionalStatus is set to 'Marked' and has priority over 'Overpaid'


### PR DESCRIPTION
Atm it only adds a comment but the order is fully paid and can be shipped there is no reason to keep it in a pending order state.