### PR TITLE
BTCPay 2.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # BTCPay Server integration for Magento 2
 
 ## Requirements
-- Magento 2.4.2 or later installation (tested on Community Edition 2.4.2)
-- Magento < 2.4 should also work, but is untested. 
-- PHP 7.2 or greater. Tested with PHP 7.4.
-- Your BTCPay Server must be setup with HTTPS or HTTP using TOR for security.
+- BTCPay Server supported versions: >=1.3.0 (including >=2.0.0)
+- Magento 2.4.2 or later installation (tested on Community Edition 2.4.6-p6)
+- Magento < 2.4 should also work, but is untested
+- PHP 8.0 or greater. Tested with PHP 8.2
+- Your BTCPay Server must be setup with HTTPS or HTTP using TOR for security
 - You need an API key for your user in BTCPay Server (new since module v2.0)
-- Single-Store Mode is not supported.
+- Single-Store Mode is not supported
 
 ## Features
 - Allows you to pay with BTCPay Server in Magento 2 stores

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=7.3",
-        "btcpayserver\/btcpayserver-greenfield-php": "^2.2"
+        "btcpayserver\/btcpayserver-greenfield-php": "^2.7"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
- Bumping PHP library for BTCPay 2.0.0+ support
- Updating readme

Although the new PHP library version 2.7.0+ with BTCPay 2.0 support would get fetched by any `composer update` run on the site I think it more clear to do a new release and bump the PHP library version so people are aware that there is BTCPay 2.0 supported from now on.
 