### PR TITLE
Fix 2.4.7-x registration and show bitcoin payment option

### DIFF
--- a/Model/BTCPay/BTCPayService.php
+++ b/Model/BTCPay/BTCPayService.php
@@ -719,7 +719,7 @@ class BTCPayService
 
     public function getWebhookSecret(int $magentoStoreId): ?string
     {
-        $secret = $this->getConfigWithoutCache('payment/btcpay/webhook_secret', 'default', 0);
+        $secret = $this->getStoreConfig('payment/btcpay/webhook_secret', 0);
         if (!$secret) {
             $secret = $this->createWebhookSecret();
 


### PR DESCRIPTION
Since 2.4.7 the bitcoin payment option didn't show up. Next to that it wasn't possible to register a btcpay instance on new installations. See:
#24 
#21 

It appeared the webhook secret was constantly changing since it couldn't retrieve the existing one in the right way. This change should fix this. I've tested this succesfully on a fresh 2.4.7-p4 instance.

Since I'm not familiar with Magento I can't oversee completely the impact of this change. Please validate. 