### PR TITLE
Fix getConfigWithoutCache() causing infinite re-generation of webhook secret

### DIFF
--- a/Model/BTCPay/BTCPayService.php
+++ b/Model/BTCPay/BTCPayService.php
@@ -598,7 +598,7 @@ class BTCPayService
 
     private function getConfigWithoutCache($path, $scope, $scopeId): ?string
     {
-        $dataCollection = $this->configValueFactory->create()->getCollection();
+        $dataCollection = $this->configCollectionFactory->create();
         $dataCollection->addFieldToFilter('path', ['like' => $path . '%']);
         $dataCollection->addFieldToFilter('scope', ['like' => $scope . '%']);
         $dataCollection->addFieldToFilter('scope_id', ['like' => $scopeId . '%']);


### PR DESCRIPTION
Instantiation of config collection, would return always null and cause infinite re-generation of webhook secret. `getCollection()` was marked deprecated for a long time but seems something broke with 2.4.7.

Fixes #21 
Fixes #25 

Background: the previously used `getCollection()` method has been deprecated for many Magento2 releases and it seems with 2.4.7 it broke or the behaviour changed without throwing an error though. It seems to always return `null` which makes the webhook secret to get changed on every config page reload and even any checking of webhook secret is set at all. I first fixed it by directly querying the database but found the proposed solution which just uses the proper existing collection to load the data. Thanks to #25 guided me in the right direction. I initially thought the problem is the enforces CSP rules but that was not the problem.